### PR TITLE
feat(repo): initialize monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+/.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,43 +39,43 @@ This reverts commit <hash>.
 ## Type
 
 Must be one of:
-feat:     A new feature
-fix:      A bug fix
-refactor: Code change without feature or bug fix
-perf:     Performance improvement
-test:     Add or update tests
-docs:     Documentation-only changes
-style:    Formatting only (no logic changes)
-chore:    Tooling, build, or dependency changes
-ci:       CI/CD workflow changes
+* feat:     A new feature
+* fix:      A bug fix
+* refactor: Code change without feature or bug fix
+* perf:     Performance improvement
+* test:     Add or update tests
+* docs:     Documentation-only changes
+* style:    Formatting only (no logic changes)
+* chore:    Tooling, build, or dependency changes
+* ci:       CI/CD workflow changes
 
 ## Scope
 
 Scope describes the subsystem affected.
 
 Approved scopes for kittybot:
-head        High-level robot head service
-tracking    PTZ math and control logic
-state       State machine
-vision      Camera and perception
-transport   PTZ/EYES/STATE protocol and transport
-ai          Prometheus AI integration
-api         FastAPI endpoints
-config      Runtime configuration
-firmware    STM32 or embedded code
-hardware    BOM, wiring, CAD
-docs        Documentation updates
-repo        Repository structure changes
-ops         Docker/compose/deployment
-ci          CI workflow changes
+* head        High-level robot head service
+* tracking    PTZ math and control logic
+* state       State machine
+* vision      Camera and perception
+* transport   PTZ/EYES/STATE protocol and transport
+* ai          Prometheus AI integration
+* api         FastAPI endpoints
+* config      Runtime configuration
+* firmware    STM32 or embedded code
+* hardware    BOM, wiring, CAD
+* docs        Documentation updates
+* repo        Repository structure changes
+* ops         Docker/compose/deployment
+* ci          CI workflow changes
 
 Use lowercase.
 
 Examples:
-feat(head): add state machine integration
-feat(tracking): implement yaw clamp limits
-fix(api): enforce api key authentication
-chore(ops): add compose.server profile
+* feat(head): add state machine integration
+* feat(tracking): implement yaw clamp limits
+* fix(api): enforce api key authentication
+* chore(ops): add compose.server profile
 
 ## Subject Rules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY pyproject.toml README.md /app/
+COPY head /app/head
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["python", "-m", "uvicorn", "head.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: install dev test lint docker-build
+
+PYTHON ?= python
+APP ?= head.app.main:app
+IMAGE ?= kittybot-head:dev
+
+install:
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -e ".[dev]"
+
+dev: install
+	$(PYTHON) -m uvicorn $(APP) --host 0.0.0.0 --port 8000 --reload
+
+test: install
+	$(PYTHON) -m pytest -q
+
+lint: install
+	$(PYTHON) -m ruff check .
+
+docker-build:
+	docker build -t $(IMAGE) .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,274 @@
 # kittybot
+
+A modular, containerized companion robot head project designed for professional-grade
+software and embedded development practices.
+
+kittybot is built to evolve from:
+
+* 🧠 Laptop-based development (Nomad)
+* 🖥 Prometheus AI stack integration
+* 🤖 Jetson deployment
+* 🔧 STM32-based actuator control
+
+This project emphasizes:
+
+* Clean architecture
+* Deterministic boundaries
+* Strong commit discipline
+* Unit testing
+* CI enforcement
+* Hardware/software separation of concerns
+
+---
+
+# 🚀 Project Vision
+
+Final goal:
+A mobile "Hello Kitty"-styled companion robot capable of:
+
+* Face tracking
+* Conversational interaction
+* Expressive animated eyes
+* Object manipulation (future)
+
+Phase 1 (Milestone 1):
+Head Service MVP running fully in software with:
+
+* Camera-based face detection
+* PTZ (pan/tilt) target calculation
+* Deterministic state machine
+* Structured logging
+* Prometheus AI integration
+* Transport abstraction (no hardware required yet)
+
+---
+
+# 🧱 Architecture Overview
+
+## High-Level Structure
+
+* `head/` → High-level robot head service (Python)
+* `tracking/` → PTZ math and smoothing logic
+* `state/` → Deterministic behavior state machine
+* `vision/` → Camera + perception
+* `transport/` → PTZ/EYES/STATE protocol abstraction
+* `ai/` → Prometheus AI client integration
+* `firmware/` → STM32 embedded firmware (future)
+* `hardware/` → BOM, wiring, CAD (future)
+* `sims/` → Actuator simulators
+
+The head service is fully testable without hardware.
+
+---
+
+# 📦 Development Workflow
+
+## 1️⃣ Clone the Repository
+
+```bash
+git clone <repo-url>
+cd kittybot
+```
+
+## 2️⃣ Local Development (Fast Loop)
+
+```bash
+make dev
+```
+
+Service runs locally and exposes:
+
+* `GET /health`
+* `GET /state`
+* `GET /metrics`
+* `GET /deps`
+* `POST /demo/talk`
+
+## 3️⃣ Run Tests
+
+```bash
+make test
+```
+
+With coverage:
+
+```bash
+make test-cov
+```
+
+## 4️⃣ Linting
+
+```bash
+make lint
+```
+
+---
+
+# 🐳 Docker Usage
+
+## Development Profile
+
+```bash
+docker compose -f head/docker/compose.dev.yml up
+```
+
+## Server Profile (Prometheus)
+
+```bash
+docker compose -f head/docker/compose.server.yml up
+```
+
+Refer to `docs/dev-runbook.md` for Portainer stack deployment steps.
+
+---
+
+# 🔐 Security Model
+
+* API key optional via `API_KEY`
+* If configured, all endpoints except `/health` require header:
+  `X-API-Key`
+* No secrets committed to repository
+* Strict timeout on outbound AI requests
+
+---
+
+# 📡 Protocol Contract (Transport Layer)
+
+Newline-delimited text commands.
+
+Units are always **degrees**.
+
+```
+PTZ <yaw_deg> <pitch_deg>
+EYES <mode>
+STATE <state>
+```
+
+Any change to protocol requires an ADR.
+
+---
+
+# 🧪 Testing Philosophy
+
+* All core logic must be unit tested
+* Tracking math must be deterministic
+* State transitions must be validated
+* Protocol formatting must be verified
+* CI must pass before merging
+
+Tests live under `head/tests/`.
+
+---
+
+# 🌐 Prometheus AI Integration
+
+Head service can call external AI endpoint:
+
+```
+POST {AI_BASE_URL}/chat
+{
+  "text": "...",
+  "session_id": "..."
+}
+```
+
+* Strict timeout
+* Fallback canned response if unavailable
+* `/deps` endpoint shows integration health
+
+---
+
+# 🛣 Roadmap
+
+### Milestone 1 — Head Service MVP
+
+* Repo structure
+* Config + logging
+* PTZ math
+* State machine
+* Transport layer
+* Camera + tracking
+* AI client
+
+### Milestone 2 — Simulation Layer
+
+* MCU simulator
+* Eyes simulator
+
+### Milestone 3 — Audio Interaction
+
+* Wake word
+* STT
+* TTS
+
+### Milestone 4 — Hardware Bring-Up
+
+* STM32 firmware
+* Display drivers
+* Servo integration
+
+### Milestone 5 — Jetson Deployment
+
+* Performance tuning
+* Systemd integration
+* GPU acceleration
+
+---
+
+# 🧭 Engineering Standards
+
+* Conventional commit format
+* One branch per issue
+* PR required for merge
+* Unit tests required for new logic
+* JSON structured logging
+* YAML runtime configuration
+* PTZ units always degrees
+
+See:
+
+* `CONTRIBUTING.md`
+* `TESTING.md`
+* `REVIEWING.md`
+
+---
+
+# 📌 Design Principles
+
+1. Deterministic boundaries
+2. Hardware abstraction
+3. Testable pure logic
+4. Small, scoped changes
+5. No premature optimization
+6. Clean upgrade path to embedded hardware
+
+---
+
+# 🧠 Why This Project Exists
+
+kittybot is both:
+
+* A companion robot platform
+* A professional robotics software portfolio project
+
+It is designed to mirror real robotics engineering workflows while
+remaining approachable and modular.
+
+---
+
+# ⚠️ Current Status
+
+Early development.
+
+Head service MVP under active construction.
+No hardware required yet.
+
+---
+
+# 📜 License
+
+(To be determined)
+
+---
+
+End of README

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# docs
+
+Design notes, architecture records, and operating procedures for kittybot live here.
+
+## Contents
+
+- ADRs and architecture decisions
+- Prompt and workflow documentation
+- Operational notes
+
+## Troubleshooting
+
+- If you cannot find a document, check the file naming pattern (`*-template.md`, `*-wrapper.md`).
+- If guidance conflicts with code, treat code as source of truth and open a follow-up ADR.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,14 @@
+# firmware
+
+Embedded firmware source and build artifacts for kittybot devices.
+
+## Contents
+
+- MCU firmware modules
+- board support configuration
+- flashing/build notes
+
+## Troubleshooting
+
+- If board support files are unclear, add a board matrix document under `docs/`.
+- If build scripts are missing, keep them scoped to this directory to avoid cross-layer coupling.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,14 @@
+# hardware
+
+Hardware design files, BOM references, and integration notes for kittybot.
+
+## Contents
+
+- mechanical/electrical artifacts
+- wiring and pinout references
+- revision notes
+
+## Troubleshooting
+
+- If a hardware revision is ambiguous, document exact revision identifiers before changes.
+- If pin mappings differ from firmware assumptions, update both this folder and related ADRs in `docs/`.

--- a/head/README.md
+++ b/head/README.md
@@ -1,0 +1,13 @@
+# head
+
+Control-plane service entry point for kittybot. This directory contains the API surface and server-side coordination logic.
+
+## Contents
+
+- `app/`: FastAPI application package
+- `tests/`: API tests for head service behavior
+
+## Troubleshooting
+
+- If imports fail, run `python -m pip install -e ".[dev]"` from repo root.
+- If local startup fails, verify the app target is `head.app.main:app`.

--- a/head/__init__.py
+++ b/head/__init__.py
@@ -1,0 +1,1 @@
+"""kittybot head package."""

--- a/head/app/README.md
+++ b/head/app/README.md
@@ -1,0 +1,13 @@
+# head/app
+
+Minimal FastAPI app for the kittybot head service.
+
+## Contents
+
+- `main.py`: API application and routes
+- `logging_config.py`: logging bootstrap placeholder
+
+## Troubleshooting
+
+- If `/health` is missing, confirm `main.py` defines `@app.get("/health")`.
+- If startup logging looks plain-text, this is expected until structured JSON logging is fully implemented.

--- a/head/app/__init__.py
+++ b/head/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application package for kittybot head."""

--- a/head/app/logging_config.py
+++ b/head/app/logging_config.py
@@ -1,0 +1,9 @@
+import logging
+
+
+def configure_logging() -> None:
+    """Configure logging.
+
+    Placeholder only: this will be replaced with shared JSON structured logging.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/head/app/main.py
+++ b/head/app/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+
+from .logging_config import configure_logging
+
+configure_logging()
+
+app = FastAPI(title="kittybot-head")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/head/tests/README.md
+++ b/head/tests/README.md
@@ -1,0 +1,13 @@
+# head/tests
+
+Tests for the `head` FastAPI service.
+
+## Contents
+
+- endpoint tests
+- integration-style API sanity checks
+
+## Troubleshooting
+
+- If tests fail on import, ensure the package is installed in editable mode: `python -m pip install -e ".[dev]"`.
+- If `TestClient` errors, verify `httpx` is installed from dev dependencies.

--- a/head/tests/test_health.py
+++ b/head/tests/test_health.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from head.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kittybot"
+version = "0.1.0"
+description = "kittybot monorepo baseline"
+readme = "README.md"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "fastapi>=0.110,<1.0",
+    "uvicorn[standard]>=0.29,<1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "httpx>=0.27,<1.0",
+    "pytest>=8.0,<9.0",
+    "ruff>=0.4,<1.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["head/tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F"]
+
+[tool.setuptools.packages.find]
+include = ["head*"]

--- a/sims/README.md
+++ b/sims/README.md
@@ -1,0 +1,14 @@
+# sims
+
+Simulation assets and runtime scaffolding for kittybot.
+
+## Contents
+
+- simulator adapters
+- scenario definitions
+- simulation tooling
+
+## Troubleshooting
+
+- If simulator files are missing, confirm they are committed under this directory instead of `tools/`.
+- If a simulation requires hardware-specific paths, document the mapping in `docs/`.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,14 @@
+# tools
+
+Developer and automation tooling for kittybot.
+
+## Contents
+
+- helper scripts
+- local automation
+- utility wrappers
+
+## Troubleshooting
+
+- If a tool depends on external binaries, document required versions in script headers.
+- If a tool mutates repository files, include a dry-run mode where practical.


### PR DESCRIPTION
## What changed
- Initialized the monorepo structure with top-level directories:
  - `docs/`
  - `head/`
  - `sims/`
  - `firmware/`
  - `hardware/`
  - `tools/`
- Added `README.md` files with a `## Troubleshooting` section for each scoped directory.
- Added a minimal FastAPI app in `head/app`:
  - `GET /health` returns `{"status":"ok"}`.
- Added a logging bootstrap placeholder (`head/app/logging_config.py`) for future JSON logging integration.
- Added API test coverage for `/health` in `head/tests/test_health.py`.
- Added `pyproject.toml` (Python 3.11 baseline) with FastAPI, pytest, and ruff.
- Added `Makefile` targets: `dev`, `test`, `lint`, `docker-build`.
- Added a minimal `Dockerfile` for the head service runtime.

## Why
- Establish a clean, stable monorepo foundation early to avoid costly refactors.
- Enforce separation of concerns across software, firmware, hardware, simulation, and tooling.
- Provide a minimal but runnable/testable backend baseline for future milestones.

## How to test
- [x] `make test`
- [x] `make lint`
- [x] Manual check: run `make dev`, then request `GET /health` and confirm `{"status":"ok"}`

## Notes
- This PR intentionally excludes tracking, transport, AI client, STM32 firmware, and camera integration.
- Docker build target is included; local build requires Docker engine/Desktop running.