### PR TITLE
ci(ci): scope workflow triggers to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
## What changed
- Scoped CI workflow triggers to `main` for both `pull_request` and `push`.
- Kept CI steps unchanged:
  - Python 3.11 on ubuntu runner
  - dependency install
  - `make lint`
  - `make test`

## Why
- Enforce required checks for PRs targeting `main` and merges to `main`.
- Align workflow behavior with branch protection expectations for Issue #3.

## How to test
- [x] `make test`
- [x] `make lint`
- [ ] Manual check: open a PR to `main` and confirm the `ci` workflow runs and passes.

## Notes
- No deployment workflow added.
- No Docker build step added.
- Closes #4 