### PR TITLE
ci(ci): replace Python pipeline with C++23 build system

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,36 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+# C++23
+Standard: c++23
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+
+# Line length
+ColumnLimit: 100
+
+# Braces
+BreakBeforeBraces: Attach
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+# Includes
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+
+# Namespaces
+NamespaceIndentation: None
+CompactNamespaces: false
+
+# Pointer alignment
+PointerAlignment: Left
+
+# Comments
+ReflowComments: true
+SpacesBeforeTrailingComments: 2

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,8 +31,8 @@ What happens now? Include logs/errors.
 
 ## Environment
 - OS:
-- Docker version:
-- Python version:
+- Compiler (e.g. g++-13, clang-17):
+- CMake version:
 - Commit hash (if known):
 
 ## Scope
@@ -40,7 +40,7 @@ Files/areas likely involved.
 
 ## Acceptance Criteria
 - [ ] Bug fixed and repro no longer fails
-- [ ] `make test` passes
+- [ ] CI passes (`build` + `format` jobs green)
 - [ ] Regression test added (if appropriate)
 - [ ] Docs updated if behavior changed
 

--- a/.github/ISSUE_TEMPLATE/codex-task--paste-directly-.md
+++ b/.github/ISSUE_TEMPLATE/codex-task--paste-directly-.md
@@ -15,18 +15,15 @@ labels: ["codex"]
 assignees: []
 ---
 
-## Paste into Codex (include wrapper)
-1) Paste `docs/codex-prompt-wrapper.md`
-2) Paste the task below
-
 ## Task Summary
 -
 
 ## Files in Scope (ONLY these may be modified/created)
-- 
+-
 
 ## Requirements
 -
 
 ## Acceptance Criteria
-- [ ]
+- [ ] CI passes (`build` + `format` jobs green)
+- [ ] 

--- a/.github/ISSUE_TEMPLATE/feature---task.md
+++ b/.github/ISSUE_TEMPLATE/feature---task.md
@@ -26,16 +26,14 @@ What must NOT be done in this issue (prevents Codex drift).
 - Do not ...
 
 ## Technical Requirements
-- Language/runtime: Python 3.11 (head) / C (STM32 later)
-- Config: YAML (`config.yaml`) if needed
-- Logging: JSON structured logs
-- Security: respect API key rules (X-API-Key) if touching HTTP
-- Transport: PTZ/EYES/STATE protocol and degrees units if touching transport
-- Tests: pytest required for new logic
+- Language/runtime: C++23 (host) / C (STM32 firmware)
+- Logging: `kittybot::Logger` for structured output
+- Transport: PTZ/EYES/STATE protocol, units always degrees
+- Tests: Catch2 unit tests required for new logic modules
 
 ## Acceptance Criteria
 - [ ] Implements only the scope described above
-- [ ] `make test` passes
+- [ ] CI passes (`build` + `format` jobs green)
 - [ ] Unit tests added/updated for new logic
 - [ ] Documentation updated (READMEs + relevant docs)
 - [ ] No secrets committed (no tokens/keys in repo)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,9 @@
 - 
 
 ## How to test
-- [ ] `make test`
-- [ ] `make lint`
+- [ ] `cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build`
+- [ ] `ctest --test-dir build --output-on-failure`
+- [ ] `clang-format` check passes (CI enforces)
 - [ ] Manual check: 
 
 ## Notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,27 +7,51 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  build:
+    name: Build & Test (C++23)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install
+      - name: Install toolchain
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build gcc-13 g++-13
 
-      - name: Lint
+      - name: Configure
         run: |
-          make lint
+          cmake -S . -B build \
+            -G Ninja \
+            -DCMAKE_CXX_COMPILER=g++-13 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build build
 
       - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  format:
+    name: clang-format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
         run: |
-          make test
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check formatting
+        run: |
+          files=$(find . -name "*.cpp" -o -name "*.hpp" -o -name "*.h" | grep -v build/)
+          if [ -z "$files" ]; then
+            echo "No C++ source files found — skipping format check."
+            exit 0
+          fi
+          echo "$files" | xargs clang-format --dry-run --Werror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(kittybot
+  VERSION 0.1.0
+  DESCRIPTION "C++23 companion robot runtime"
+  LANGUAGES CXX
+)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Compiler warnings
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Testing
+include(CTest)
+if(BUILD_TESTING)
+  # add_subdirectory(tests) -- uncomment when tests exist (Month 1 Week 4)
+endif()
+
+# Modules added here as they're built (Month 1+)
+# add_subdirectory(src)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to KittyBot
+
+## Branching
+
+- One branch per issue: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`, `docs/<scope>`
+- Branch from `main`, PR back to `main`
+- No direct pushes to `main`
+
+## Commit Format
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`
+Breaking changes: append `!` to the type (e.g. `feat!:`)
+
+## Pull Requests
+
+- Fill out the PR template
+- CI must be green before merge
+- Self-review before requesting review
+
+## CI
+
+Two required checks:
+
+| Job | What it does |
+|-----|-------------|
+| `build` | CMake configure → build → `ctest` |
+| `format` | `clang-format --dry-run --Werror` on all `.cpp`/`.hpp` |
+
+Run locally before pushing:
+
+```bash
+# Build and test
+cmake -S . -B build -DBUILD_TESTING=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+
+# Format check (dry run)
+find . -name "*.cpp" -o -name "*.hpp" | grep -v build/ | xargs clang-format --dry-run --Werror
+
+# Auto-fix formatting
+find . -name "*.cpp" -o -name "*.hpp" | grep -v build/ | xargs clang-format -i
+```
+
+## Code Standards
+
+- C++23, no exceptions in embedded-facing code
+- All new logic modules need unit tests (Month 1 Week 4+)
+- No Python in `src/` or `firmware/` — Python tooling lives in `tools/scripts/` only if needed
+- Follow the `.clang-format` config — non-negotiable
+- No secrets or credentials committed
+
+## Architecture Decisions
+
+Significant decisions go in `docs/decisions/` as ADRs before implementation.
+See `docs/decisions/ADR-0000-template.md`.


### PR DESCRIPTION
## What changed
- Replaced Python/pip/make CI with a two-job C++23 pipeline (`build` + `format`)
- Added root `CMakeLists.txt` scaffold (C++23, GCC-13, CTest enabled) so CI can actually run cmake
- Added `.clang-format` config (Google base, 100-col, C++23 standard)
- Added `CONTRIBUTING.md` covering branch/commit/CI workflow for C++23
- Updated PR template and all three issue templates to reference cmake/ctest instead of make/pytest/Python

## Why
- The repo reset to C++23 left the CI running Python tooling against a project that has no Python — it would fail on every push
- CMakeLists.txt is a scaffold only (no sources yet); CI passes green while the build system grows into it through Month 1

## How to test
- [ ] CI `build` job: cmake configure → build → ctest — all pass (no sources yet = no failures)
- [ ] CI `format` job: no .cpp/.hpp files found → skips cleanly with exit 0
- [ ] PR/issue templates reference cmake and ctest, not make/Python

## Notes
- `src/` and `tests/` subdirectory hooks are commented out in CMakeLists.txt — uncomment as modules are added in Month 1
- Catch2 referenced in feature template but not yet added as a dependency — that's Month 1 Week 4 work