### PR TITLE
feat(logger): implement kittybot::Logger and ScopeGuard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ Language: Cpp
 BasedOnStyle: Google
 
 # C++23
-Standard: c++23
+Standard: Latest
 
 # Indentation
 IndentWidth: 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,7 @@ endif()
 # Testing
 include(CTest)
 if(BUILD_TESTING)
-  # add_subdirectory(tests) -- uncomment when tests exist (Month 1 Week 4)
+  add_subdirectory(tests)
 endif()
 
-# Modules added here as they're built (Month 1+)
-# add_subdirectory(src)
+add_subdirectory(src)

--- a/include/kittybot/logger.hpp
+++ b/include/kittybot/logger.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+namespace kittybot {
+
+enum class LogLevel { Debug = 0, Info = 1, Warn = 2, Error = 3 };
+
+/// Thread-safe logger with RAII file management.
+///
+/// Writes structured lines to stdout and/or a log file:
+///   [YYYY-MM-DD HH:MM:SS.mmm] [LEVEL] message
+///
+/// The log file is opened in the constructor and flushed+closed in the
+/// destructor — no explicit teardown required.
+///
+/// Non-copyable, non-movable (holds a std::mutex).
+class Logger {
+   public:
+    struct Config {
+        LogLevel min_level = LogLevel::Info;
+        bool stdout_enabled = true;
+        std::filesystem::path log_file{};  ///< Empty = no file output.
+    };
+
+    explicit Logger(Config cfg);
+    ~Logger();
+
+    Logger(const Logger&) = delete;
+    Logger& operator=(const Logger&) = delete;
+    Logger(Logger&&) = delete;
+    Logger& operator=(Logger&&) = delete;
+
+    void log(LogLevel level, std::string_view message);
+
+    void debug(std::string_view msg) { log(LogLevel::Debug, msg); }
+    void info(std::string_view msg) { log(LogLevel::Info, msg); }
+    void warn(std::string_view msg) { log(LogLevel::Warn, msg); }
+    void error(std::string_view msg) { log(LogLevel::Error, msg); }
+
+   private:
+    Config cfg_;
+    std::ofstream file_;
+    std::mutex mu_;
+
+    static std::string_view level_str(LogLevel l) noexcept;
+    static std::string timestamp_now();
+};
+
+}  // namespace kittybot

--- a/include/kittybot/scope_guard.hpp
+++ b/include/kittybot/scope_guard.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <functional>
+#include <utility>
+
+namespace kittybot {
+
+/// RAII scope guard. Runs a callable unconditionally on destruction.
+///
+/// Use make_scope_guard() to create one — the [[nodiscard]] return type
+/// forces binding to a named variable, which is the only correct usage.
+///
+/// Example:
+///   auto guard = make_scope_guard([&] { cleanup(); });
+///   // ... do work that might throw ...
+///   guard.disarm();  // commit: prevent cleanup on success path
+class ScopeGuard {
+   public:
+    explicit ScopeGuard(std::function<void()> fn) : fn_{std::move(fn)} {}
+
+    ~ScopeGuard() {
+        if (active_)
+            fn_();
+    }
+
+    ScopeGuard(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(const ScopeGuard&) = delete;
+
+    ScopeGuard(ScopeGuard&& o) noexcept : fn_{std::move(o.fn_)}, active_{o.active_} {
+        o.active_ = false;
+    }
+    ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+    /// Prevent the cleanup action from running on destruction.
+    void disarm() noexcept { active_ = false; }
+
+   private:
+    std::function<void()> fn_;
+    bool active_ = true;
+};
+
+/// Factory for ScopeGuard. [[nodiscard]]: discarding the return value is a bug —
+/// the guard fires immediately and never runs at scope exit.
+template <typename Fn>
+[[nodiscard]] ScopeGuard make_scope_guard(Fn&& fn) {
+    return ScopeGuard{std::forward<Fn>(fn)};
+}
+
+}  // namespace kittybot

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(kittybot_core STATIC
+    kittybot/logger.cpp
+)
+
+target_include_directories(kittybot_core PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+find_package(Threads REQUIRED)
+target_link_libraries(kittybot_core
+    PRIVATE Threads::Threads
+)
+
+target_compile_features(kittybot_core PUBLIC cxx_std_23)

--- a/src/kittybot/logger.cpp
+++ b/src/kittybot/logger.cpp
@@ -1,0 +1,72 @@
+#include "kittybot/logger.hpp"
+
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <stdexcept>
+
+namespace kittybot {
+
+Logger::Logger(Config cfg) : cfg_{std::move(cfg)} {
+    if (!cfg_.log_file.empty()) {
+        file_.open(cfg_.log_file, std::ios::app);
+        if (!file_.is_open()) {
+            throw std::runtime_error{
+                std::format("Logger: cannot open log file '{}'", cfg_.log_file.string())};
+        }
+    }
+}
+
+Logger::~Logger() {
+    if (file_.is_open()) {
+        file_.flush();
+    }
+}
+
+void Logger::log(LogLevel level, std::string_view message) {
+    if (level < cfg_.min_level)
+        return;
+
+    auto line = std::format("[{}] [{}] {}\n", timestamp_now(), level_str(level), message);
+
+    std::lock_guard lock{mu_};
+    if (cfg_.stdout_enabled) {
+        std::cout << line;
+    }
+    if (file_.is_open()) {
+        file_ << line;
+    }
+}
+
+std::string_view Logger::level_str(LogLevel l) noexcept {
+    switch (l) {
+        case LogLevel::Debug:
+            return "DEBUG";
+        case LogLevel::Info:
+            return "INFO ";
+        case LogLevel::Warn:
+            return "WARN ";
+        case LogLevel::Error:
+            return "ERROR";
+    }
+    return "";  // unreachable — all enum values covered above
+}
+
+std::string Logger::timestamp_now() {
+    using namespace std::chrono;
+    auto now = system_clock::now();
+    auto dp = floor<days>(now);
+    year_month_day ymd{dp};
+    auto tod = now - dp;
+    auto h = duration_cast<hours>(tod);
+    auto m = duration_cast<minutes>(tod - h);
+    auto s = duration_cast<seconds>(tod - h - m);
+    auto ms = duration_cast<milliseconds>(tod - h - m - s);
+
+    return std::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:03d}",
+                       static_cast<int>(ymd.year()), static_cast<unsigned>(ymd.month()),
+                       static_cast<unsigned>(ymd.day()), h.count(), m.count(), s.count(),
+                       ms.count());
+}
+
+}  // namespace kittybot

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.7.1
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(Catch2)
+
+add_executable(kittybot_tests
+    test_logger.cpp
+)
+
+target_link_libraries(kittybot_tests
+    PRIVATE kittybot_core
+    PRIVATE Catch2::Catch2WithMain
+)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+include(Catch)
+catch_discover_tests(kittybot_tests)

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1,0 +1,147 @@
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "kittybot/logger.hpp"
+#include "kittybot/scope_guard.hpp"
+
+namespace fs = std::filesystem;
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+static std::string read_file(const fs::path& p) {
+    std::ifstream f{p};
+    return {std::istreambuf_iterator<char>{f}, {}};
+}
+
+// ─── ScopeGuard ───────────────────────────────────────────────────────────────
+
+TEST_CASE("ScopeGuard: runs cleanup on scope exit", "[scope_guard]") {
+    bool ran = false;
+    {
+        auto guard = kittybot::make_scope_guard([&ran] { ran = true; });
+        CHECK(!ran);
+    }
+    CHECK(ran);
+}
+
+TEST_CASE("ScopeGuard: disarm prevents cleanup", "[scope_guard]") {
+    bool ran = false;
+    {
+        auto guard = kittybot::make_scope_guard([&ran] { ran = true; });
+        guard.disarm();
+    }
+    CHECK(!ran);
+}
+
+// ─── Logger ───────────────────────────────────────────────────────────────────
+
+TEST_CASE("Logger: RAII - file created on construction, flushed on destruction", "[logger]") {
+    auto tmp = fs::temp_directory_path() / "kb_test_raii.log";
+    auto cleanup = kittybot::make_scope_guard([&] { fs::remove(tmp); });
+
+    {
+        kittybot::Logger logger{{
+            .min_level = kittybot::LogLevel::Debug,
+            .stdout_enabled = false,
+            .log_file = tmp,
+        }};
+        CHECK(fs::exists(tmp));
+        logger.info("hello raii");
+    }  // RAII: logger destroyed here, file flushed and closed
+
+    CHECK(read_file(tmp).find("hello raii") != std::string::npos);
+}
+
+TEST_CASE("Logger: messages below min_level are suppressed", "[logger]") {
+    auto tmp = fs::temp_directory_path() / "kb_test_filter.log";
+    auto cleanup = kittybot::make_scope_guard([&] { fs::remove(tmp); });
+
+    {
+        kittybot::Logger logger{{
+            .min_level = kittybot::LogLevel::Warn,
+            .stdout_enabled = false,
+            .log_file = tmp,
+        }};
+        logger.debug("suppressed");
+        logger.info("suppressed");
+        logger.warn("visible");
+        logger.error("visible");
+    }
+
+    auto contents = read_file(tmp);
+    CHECK(contents.find("suppressed") == std::string::npos);
+    CHECK(contents.find("visible") != std::string::npos);
+}
+
+TEST_CASE("Logger: all log levels produce distinct tags", "[logger]") {
+    auto tmp = fs::temp_directory_path() / "kb_test_levels.log";
+    auto cleanup = kittybot::make_scope_guard([&] { fs::remove(tmp); });
+
+    {
+        kittybot::Logger logger{{
+            .min_level = kittybot::LogLevel::Debug,
+            .stdout_enabled = false,
+            .log_file = tmp,
+        }};
+        logger.debug("d");
+        logger.info("i");
+        logger.warn("w");
+        logger.error("e");
+    }
+
+    auto contents = read_file(tmp);
+    CHECK(contents.find("DEBUG") != std::string::npos);
+    CHECK(contents.find("INFO") != std::string::npos);
+    CHECK(contents.find("WARN") != std::string::npos);
+    CHECK(contents.find("ERROR") != std::string::npos);
+}
+
+TEST_CASE("Logger: stdout-only mode does not throw", "[logger]") {
+    CHECK_NOTHROW([] {
+        kittybot::Logger logger{{
+            .min_level = kittybot::LogLevel::Info,
+            .stdout_enabled = false,
+            .log_file = {},
+        }};
+        logger.info("no file, no problem");
+    }());
+}
+
+TEST_CASE("Logger: thread-safe under concurrent writes", "[logger]") {
+    auto tmp = fs::temp_directory_path() / "kb_test_threads.log";
+    auto cleanup = kittybot::make_scope_guard([&] { fs::remove(tmp); });
+
+    constexpr int kThreads = 8;
+    constexpr int kMsgs = 50;
+
+    {
+        kittybot::Logger logger{{
+            .min_level = kittybot::LogLevel::Debug,
+            .stdout_enabled = false,
+            .log_file = tmp,
+        }};
+
+        std::vector<std::jthread> threads;
+        threads.reserve(kThreads);
+        for (int t = 0; t < kThreads; ++t) {
+            threads.emplace_back([&logger, t] {
+                for (int i = 0; i < kMsgs; ++i) {
+                    logger.info(std::format("t{} msg{}", t, i));
+                }
+            });
+        }
+        // std::jthread joins on destruction — RAII, no explicit join needed
+    }
+
+    int lines = 0;
+    std::string line;
+    std::ifstream f{tmp};
+    while (std::getline(f, line))
+        ++lines;
+    CHECK(lines == kThreads * kMsgs);
+}


### PR DESCRIPTION
## Summary
Week 1 deliverable — \`kittybot::Logger\` and \`ScopeGuard\`.

- **\`ScopeGuard\`** — RAII cleanup on scope exit, \`disarm()\` to cancel. \`make_scope_guard()\` is \`[[nodiscard]]\` so discarding it is a compile-time bug.
- **\`Logger\`** — file opened in constructor, flushed+closed in destructor. \`std::mutex\` serialises all writes. Configurable level filter, stdout toggle, optional file path. Output: \`[YYYY-MM-DD HH:MM:SS.mmm] [LEVEL] message\`.
- **Tests** — 5 Catch2 tests: RAII lifecycle, level filtering, level tag distinctness, stdout-only mode, 8-thread concurrent write stress.
- **\`.clang-format\` fix** — \`Standard: c++23\` → \`Standard: Latest\` (invalid enumeration value caught locally).

Closes #18

## Test plan
- [ ] CI `build` job passes (CMake + Ninja + ctest)
- [ ] CI `format` job passes (clang-format --dry-run --Werror)
- [ ] All 7 Catch2 tests green in CI output